### PR TITLE
Iterative metadata check

### DIFF
--- a/scripts/metadata_check.py
+++ b/scripts/metadata_check.py
@@ -11,6 +11,10 @@ import sys
 # Gets Archive-It account credentials from the configuration file.
 import configuration as c
 
+
+def get_collection_report():
+
+
 def get_metadata_value(data, field):
     """Looks up the value of a field in the Archive-It API output for a particular collection or seed. If the field
     is not in the output, returns the string NONE instead."""
@@ -19,9 +23,6 @@ def get_metadata_value(data, field):
     except KeyError:
         return 'NONE'
 
-
-# All seeds from these collections (BMAC, DLG, and tests) will be excluded from the reports.
-skip_collections = [11071, 12249, 12274, 12470]
 
 # Makes the folder where the reports will be saved (provided by user) the current directory.
 output_directory = sys.argv[1]
@@ -54,10 +55,6 @@ with open('hargrett_collections_metadata.csv', 'w', newline='') as harg_output, 
 
     # Iterates over the metadata for each collection.
     for coll_data in py_collections:
-
-        # Does not check collections if they are not Hargrett or Russell.
-        if coll_data['id'] in skip_collections:
-            continue
 
         # Constructs the URL of the collection's metadata page to make it easy to edit a record.
         collection_metadata_page = f"{c.inst_page}/collections/{coll_data['id']}/metadata"

--- a/scripts/metadata_check.py
+++ b/scripts/metadata_check.py
@@ -13,11 +13,20 @@ import configuration as c
 
 
 def get_metadata_value(data, field):
-    """Looks up the value of a field in the Archive-It API output for a particular collection or seed. If the field
-    is not in the output, returns the string NONE instead."""
-    # TODO: if there is more than one value for the same metadata field, this only gets the value of one. See seed language for example.
+    """Looks up the value(s) of a field in the Archive-It API output for a particular collection or seed. If the
+    field is not in the output, returns the string NONE instead. """
+
     try:
-        return data['metadata'][field][0]['value']
+        # Makes a list of all the values for that data field. Some fields may repeat, e.g. language.
+        values_list = []
+        for value in data['metadata'][field]:
+            values_list.append(value['value'])
+
+        # Converts the list to a string.
+        # When there are multiple values in the list, each value is separated by a semicolon.
+        values = '; '.join(values_list)
+        return values
+
     except KeyError:
         return 'NONE'
 

--- a/scripts/metadata_check.py
+++ b/scripts/metadata_check.py
@@ -12,9 +12,6 @@ import sys
 import configuration as c
 
 
-def get_collection_report():
-
-
 def get_metadata_value(data, field):
     """Looks up the value of a field in the Archive-It API output for a particular collection or seed. If the field
     is not in the output, returns the string NONE instead."""
@@ -42,85 +39,78 @@ if not collections.status_code == 200:
 # Saves the collection data as a Python object.
 py_collections = collections.json()
 
-# Makes CSVs (one per department) to save results to, including adding header rows.
-with open('hargrett_collections_metadata.csv', 'w', newline='') as harg_output, open('russell_collections_metadata.csv', 'w', newline='') as rbrl_output, open('none_collections_metadata.csv', 'w', newline='') as none_output:
-    collection_header = ['Collection ID', 'Collection Name', 'Collector', 'Date', 'Description', 'Title', 'Collection Page']
-    harg_write = csv.writer(harg_output)
-    harg_write.writerow(collection_header)
-    rbrl_write = csv.writer(rbrl_output)
-    rbrl_write.writerow(collection_header)
-    none_write = csv.writer(none_output)
-    none_write.writerow(collection_header)
+# Iterates over the metadata for each collection.
+for coll_data in py_collections:
 
-    # Iterates over the metadata for each collection.
-    for coll_data in py_collections:
+    # Constructs the URL of the collection's metadata page to make it easy to edit a record.
+    collection_metadata_page = f"{c.inst_page}/collections/{coll_data['id']}/metadata"
 
-        # Constructs the URL of the collection's metadata page to make it easy to edit a record.
-        collection_metadata_page = f"{c.inst_page}/collections/{coll_data['id']}/metadata"
+    # Gets the values of the required metadata fields (or 'NONE' if the field has no metadata).
+    coll_collector = get_metadata_value(coll_data, 'Collector')
+    coll_date = get_metadata_value(coll_data, 'Date')
+    coll_description = get_metadata_value(coll_data, 'Description')
+    coll_title = get_metadata_value(coll_data, 'Title')
 
-        # Gets the values of the required metadata fields (or 'NONE' if the field has no metadata).
-        coll_collector = get_metadata_value(coll_data, 'Collector')
-        coll_date = get_metadata_value(coll_data, 'Date')
-        coll_description = get_metadata_value(coll_data, 'Description')
-        coll_title = get_metadata_value(coll_data, 'Title')
+    # If this is the first collection for this department, makes a CSV with a header row for collection metadata.
+    if not os.path.exists(f'{coll_collector}_collections_metadata.csv'):
+        with open(f'{coll_collector}_collections_metadata.csv', 'w', newline='') as output:
+            collection_header = ['Collection ID', 'Collection Name', 'Collector', 'Date', 'Description', 'Title',
+                                 'Collection Page']
+            header_write = csv.writer(output)
+            header_write.writerow(collection_header)
 
-        # Adds a row to the appropriate CSV with the metadata for the collection.
-        if coll_collector == 'Hargrett Rare Book & Manuscript Library':
-            harg_write.writerow([coll_data['id'], coll_data['name'], coll_collector, coll_date, coll_description,
-                                 coll_title, collection_metadata_page])
-        elif coll_collector == 'NONE':
-            none_write.writerow([coll_data['id'], coll_data['name'], coll_collector, coll_date, coll_description,
-                                 coll_title, collection_metadata_page])
-        else:
-            rbrl_write.writerow([coll_data['id'], coll_data['name'], coll_collector, coll_date, coll_description,
-                                 coll_title, collection_metadata_page])
+    # Adds the collection metadata as a row to the department's CSV.
+    with open(f'{coll_collector}_collections_metadata.csv', 'a', newline='') as output:
+        row_write = csv.writer(output)
+        row_write.writerow([coll_data['id'], coll_data['name'], coll_collector, coll_date, coll_description, coll_title,
+                            collection_metadata_page])
 
 
-# PART TWO: SEED REPORTS
-
-# Gets the Archive-It seed report with data on all the seeds.
-seeds = requests.get(f'{c.partner_api}/seed?limit=-1', auth=(c.username, c.password))
-
-# If there was an error with the API call, quits the script.
-if not seeds.status_code == 200:
-    print('Error with Archive-It API connection when getting seed report', seeds.status_code)
-    exit()
-
-# Saves the seed data as a Python object.
-py_seeds = seeds.json()
-
-# Makes CSVs (one per department) to save results to, including adding header rows.
-with open('hargrett_seeds_metadata.csv', 'w', newline='') as harg_output, open('russell_seeds_metadata.csv', 'w', newline='') as rbrl_output, open('none_seeds_metadata.csv', 'w', newline='') as none_output:
-    seed_header = ['Seed ID', 'URL', 'Collector', 'Creator', 'Date', 'Identifier', 'Language', 'Rights', 'Title', 'Metadata Page']
-    harg_write = csv.writer(harg_output)
-    harg_write.writerow(seed_header)
-    rbrl_write = csv.writer(rbrl_output)
-    rbrl_write.writerow([seed_header])
-    none_write = csv.writer(none_output)
-    none_write.writerow([seed_header])
-
-    # Iterates over the metadata for each seed.
-    for seed_data in py_seeds:
-
-        # Constructs the URL of the seed's metadata page to make it easy to edit a record.
-        seed_metadata_page = f"{c.inst_page}/collections/{seed_data['collection']}/seeds/{seed_data['id']}/metadata"
-
-        # Gets the values of the required metadata fields (or 'NONE' if the field has no metadata).
-        collector = get_metadata_value(seed_data, 'Collector')
-        creator = get_metadata_value(seed_data, 'Creator')
-        date = get_metadata_value(seed_data, 'Date')
-        identifier = get_metadata_value(seed_data, 'Identifier')
-        language = get_metadata_value(seed_data, 'Language')
-        rights = get_metadata_value(seed_data, 'Rights')
-        title = get_metadata_value(seed_data, 'Title')
-
-        # Adds a row to the appropriate CSV with the metadata for the seed.
-        if collector == 'Hargrett Rare Book & Manuscript Library':
-            harg_write.writerow([seed_data['id'], seed_data['url'], collector, creator, date, identifier, language,
-                                 rights, title, seed_metadata_page])
-        elif collector == 'NONE':
-            none_write.writerow([seed_data['id'], seed_data['url'], collector, creator, date, identifier, language,
-                                 rights, title, seed_metadata_page])
-        else:
-            rbrl_write.writerow([seed_data['id'], seed_data['url'], collector, creator, date, identifier, language,
-                                 rights, title, seed_metadata_page])
+# # PART TWO: SEED REPORTS
+#
+# # Gets the Archive-It seed report with data on all the seeds.
+# seeds = requests.get(f'{c.partner_api}/seed?limit=-1', auth=(c.username, c.password))
+#
+# # If there was an error with the API call, quits the script.
+# if not seeds.status_code == 200:
+#     print('Error with Archive-It API connection when getting seed report', seeds.status_code)
+#     exit()
+#
+# # Saves the seed data as a Python object.
+# py_seeds = seeds.json()
+#
+# # Makes CSVs (one per department) to save results to, including adding header rows.
+# with open('hargrett_seeds_metadata.csv', 'w', newline='') as harg_output, open('russell_seeds_metadata.csv', 'w', newline='') as rbrl_output, open('none_seeds_metadata.csv', 'w', newline='') as none_output:
+#     seed_header = ['Seed ID', 'URL', 'Collector', 'Creator', 'Date', 'Identifier', 'Language', 'Rights', 'Title', 'Metadata Page']
+#     harg_write = csv.writer(harg_output)
+#     harg_write.writerow(seed_header)
+#     rbrl_write = csv.writer(rbrl_output)
+#     rbrl_write.writerow([seed_header])
+#     none_write = csv.writer(none_output)
+#     none_write.writerow([seed_header])
+#
+#     # Iterates over the metadata for each seed.
+#     for seed_data in py_seeds:
+#
+#         # Constructs the URL of the seed's metadata page to make it easy to edit a record.
+#         seed_metadata_page = f"{c.inst_page}/collections/{seed_data['collection']}/seeds/{seed_data['id']}/metadata"
+#
+#         # Gets the values of the required metadata fields (or 'NONE' if the field has no metadata).
+#         collector = get_metadata_value(seed_data, 'Collector')
+#         creator = get_metadata_value(seed_data, 'Creator')
+#         date = get_metadata_value(seed_data, 'Date')
+#         identifier = get_metadata_value(seed_data, 'Identifier')
+#         language = get_metadata_value(seed_data, 'Language')
+#         rights = get_metadata_value(seed_data, 'Rights')
+#         title = get_metadata_value(seed_data, 'Title')
+#
+#         # Adds a row to the appropriate CSV with the metadata for the seed.
+#         if collector == 'Hargrett Rare Book & Manuscript Library':
+#             harg_write.writerow([seed_data['id'], seed_data['url'], collector, creator, date, identifier, language,
+#                                  rights, title, seed_metadata_page])
+#         elif collector == 'NONE':
+#             none_write.writerow([seed_data['id'], seed_data['url'], collector, creator, date, identifier, language,
+#                                  rights, title, seed_metadata_page])
+#         else:
+#             rbrl_write.writerow([seed_data['id'], seed_data['url'], collector, creator, date, identifier, language,
+#                                  rights, title, seed_metadata_page])

--- a/scripts/metadata_check.py
+++ b/scripts/metadata_check.py
@@ -15,6 +15,7 @@ import configuration as c
 def get_metadata_value(data, field):
     """Looks up the value of a field in the Archive-It API output for a particular collection or seed. If the field
     is not in the output, returns the string NONE instead."""
+    # TODO: if there is more than one value for the same metadata field, this only gets the value of one. See seed language for example.
     try:
         return data['metadata'][field][0]['value']
     except KeyError:
@@ -66,51 +67,44 @@ for coll_data in py_collections:
                             collection_metadata_page])
 
 
-# # PART TWO: SEED REPORTS
-#
-# # Gets the Archive-It seed report with data on all the seeds.
-# seeds = requests.get(f'{c.partner_api}/seed?limit=-1', auth=(c.username, c.password))
-#
-# # If there was an error with the API call, quits the script.
-# if not seeds.status_code == 200:
-#     print('Error with Archive-It API connection when getting seed report', seeds.status_code)
-#     exit()
-#
-# # Saves the seed data as a Python object.
-# py_seeds = seeds.json()
-#
-# # Makes CSVs (one per department) to save results to, including adding header rows.
-# with open('hargrett_seeds_metadata.csv', 'w', newline='') as harg_output, open('russell_seeds_metadata.csv', 'w', newline='') as rbrl_output, open('none_seeds_metadata.csv', 'w', newline='') as none_output:
-#     seed_header = ['Seed ID', 'URL', 'Collector', 'Creator', 'Date', 'Identifier', 'Language', 'Rights', 'Title', 'Metadata Page']
-#     harg_write = csv.writer(harg_output)
-#     harg_write.writerow(seed_header)
-#     rbrl_write = csv.writer(rbrl_output)
-#     rbrl_write.writerow([seed_header])
-#     none_write = csv.writer(none_output)
-#     none_write.writerow([seed_header])
-#
-#     # Iterates over the metadata for each seed.
-#     for seed_data in py_seeds:
-#
-#         # Constructs the URL of the seed's metadata page to make it easy to edit a record.
-#         seed_metadata_page = f"{c.inst_page}/collections/{seed_data['collection']}/seeds/{seed_data['id']}/metadata"
-#
-#         # Gets the values of the required metadata fields (or 'NONE' if the field has no metadata).
-#         collector = get_metadata_value(seed_data, 'Collector')
-#         creator = get_metadata_value(seed_data, 'Creator')
-#         date = get_metadata_value(seed_data, 'Date')
-#         identifier = get_metadata_value(seed_data, 'Identifier')
-#         language = get_metadata_value(seed_data, 'Language')
-#         rights = get_metadata_value(seed_data, 'Rights')
-#         title = get_metadata_value(seed_data, 'Title')
-#
-#         # Adds a row to the appropriate CSV with the metadata for the seed.
-#         if collector == 'Hargrett Rare Book & Manuscript Library':
-#             harg_write.writerow([seed_data['id'], seed_data['url'], collector, creator, date, identifier, language,
-#                                  rights, title, seed_metadata_page])
-#         elif collector == 'NONE':
-#             none_write.writerow([seed_data['id'], seed_data['url'], collector, creator, date, identifier, language,
-#                                  rights, title, seed_metadata_page])
-#         else:
-#             rbrl_write.writerow([seed_data['id'], seed_data['url'], collector, creator, date, identifier, language,
-#                                  rights, title, seed_metadata_page])
+# PART TWO: SEED REPORTS
+
+# Gets the Archive-It seed report with data on all the seeds.
+seeds = requests.get(f'{c.partner_api}/seed?limit=-1', auth=(c.username, c.password))
+
+# If there was an error with the API call, quits the script.
+if not seeds.status_code == 200:
+    print('Error with Archive-It API connection when getting seed report', seeds.status_code)
+    exit()
+
+# Saves the seed data as a Python object.
+py_seeds = seeds.json()
+
+# Iterates over the metadata for each seed.
+for seed_data in py_seeds:
+
+    # Constructs the URL of the seed's metadata page to make it easy to edit a record.
+    seed_metadata_page = f"{c.inst_page}/collections/{seed_data['collection']}/seeds/{seed_data['id']}/metadata"
+
+    # Gets the values of the required metadata fields (or 'NONE' if the field has no metadata).
+    collector = get_metadata_value(seed_data, 'Collector')
+    creator = get_metadata_value(seed_data, 'Creator')
+    date = get_metadata_value(seed_data, 'Date')
+    identifier = get_metadata_value(seed_data, 'Identifier')
+    language = get_metadata_value(seed_data, 'Language')
+    rights = get_metadata_value(seed_data, 'Rights')
+    title = get_metadata_value(seed_data, 'Title')
+
+    # If this is the first seed for this department, makes a CSV with a header row for seed metadata.
+    if not os.path.exists(f'{collector}_seeds_metadata.csv'):
+        with open(f'{collector}_seeds_metadata.csv', 'w', newline='') as output:
+            seed_header = ['Seed ID', 'URL', 'Collector', 'Creator', 'Date', 'Identifier', 'Language', 'Rights',
+                           'Title', 'Metadata Page']
+            header_write = csv.writer(output)
+            header_write.writerow(seed_header)
+
+    # Adds the seed metadata as a row to the department's CSV.
+    with open(f'{collector}_seeds_metadata.csv', 'a', newline='') as output:
+        row_write = csv.writer(output)
+        row_write.writerow([seed_data['id'], seed_data['url'], collector, creator, date, identifier, language, rights,
+                            title, seed_metadata_page])

--- a/scripts/metadata_check.py
+++ b/scripts/metadata_check.py
@@ -102,10 +102,6 @@ with open('hargrett_seeds_metadata.csv', 'w', newline='') as harg_output, open('
     # Iterates over the metadata for each seed.
     for seed_data in py_seeds:
 
-        # Does not check seeds from collections if they are not Hargrett or Russell.
-        if seed_data['collection'] in skip_collections:
-            continue
-
         # Constructs the URL of the seed's metadata page to make it easy to edit a record.
         seed_metadata_page = f"{c.inst_page}/collections/{seed_data['collection']}/seeds/{seed_data['id']}/metadata"
 

--- a/scripts/metadata_check.py
+++ b/scripts/metadata_check.py
@@ -30,7 +30,6 @@ os.chdir(output_directory)
 
 
 # PART ONE: COLLECTION REPORTS
-print("Making collection metadata reports.")
 
 # Gets the Archive-It collection report with data on all the collections.
 collections = requests.get(f'{c.partner_api}/collection?limit=-1', auth=(c.username, c.password))
@@ -78,7 +77,6 @@ with open('hargrett_collections_metadata.csv', 'w', newline='') as harg_output, 
 
 
 # PART TWO: SEED REPORTS
-print("Making seed metadata reports.")
 
 # Gets the Archive-It seed report with data on all the seeds.
 seeds = requests.get(f'{c.partner_api}/seed?limit=-1', auth=(c.username, c.password))


### PR DESCRIPTION
Change to how reports are generated. Previously were making one report per known collector and then iterating on the collection and seed information. To simplify the code and make more flexible re: adding new collectors, it now iterates over the collection and seed information first and then makes new reports or adds to existing reports as it goes.

Also fixed an error with how the script was handling fields that repeat. Previously, it would just get the first value. Now, it gets all the values and separates them with semicolons.