### PR TITLE
Multiple crawldef

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ scripts/configuration.py
 scripts/aip_functions.py
 scripts/_pycache_
 *.pyc
+test_files/

--- a/scripts/web_aip_batch.py
+++ b/scripts/web_aip_batch.py
@@ -101,6 +101,7 @@ for warc in warc_metadata['files']:
 
     # Saves relevant information the WARC's seed in variables for future use.
     # Stops processing if the WARC does not the required metadata.
+    # TODO: dont' get crawl definition here anymore
     try:
         aip_id = seed_metadata[seed_id][0]
         aip_title = seed_metadata[seed_id][1]
@@ -120,6 +121,7 @@ for warc in warc_metadata['files']:
 
     # Downloads the seed metadata from Archive-It into the seed's metadata folder if it is not already there (and so
     # the folder is empty). A seed may have multiple WARCs and only want to download the seed's reports once.
+    # TODO: don't need crawl definition here anymore
     if len(os.listdir(f'{aip_name}/metadata')) == 0:
         web.download_metadata(aip_id, aip_name, warc_collection, crawl_definition, seed_id, current_download, log_path)
 

--- a/scripts/web_aip_batch.py
+++ b/scripts/web_aip_batch.py
@@ -125,10 +125,9 @@ for warc in warc_metadata['files']:
     # Makes the AIP directory for the seed's AIP (AIP folder with metadata and objects subfolders).
     web.make_aip_directory(aip_name)
 
-    # Downloads the seed metadata from Archive-It into the seed's metadata folder if it is not already there (and so
-    # the folder is empty). A seed may have multiple WARCs and only want to download the seed's reports once.
-    if len(os.listdir(f'{aip_name}/metadata')) == 0:
-        web.download_metadata(aip_id, aip_name, warc_collection, job_id, seed_id, current_download, log_path)
+    # Downloads the seed metadata from Archive-It into the seed's metadata folder.
+    # Only downloads if the metadata is not already present from other WARCs from the same seed.
+    web.download_metadata(aip_id, aip_name, warc_collection, job_id, seed_id, current_download, log_path)
 
     # Downloads the WARC from Archive-It into the seed's objects folder.
     web.download_warc(aip_name, warc_filename, warc_url, warc_md5, current_download, log_path)

--- a/scripts/web_aip_batch.py
+++ b/scripts/web_aip_batch.py
@@ -127,7 +127,6 @@ for warc in warc_metadata['files']:
 
     # Downloads the seed metadata from Archive-It into the seed's metadata folder if it is not already there (and so
     # the folder is empty). A seed may have multiple WARCs and only want to download the seed's reports once.
-    # TODO: don't need crawl definition here anymore
     if len(os.listdir(f'{aip_name}/metadata')) == 0:
         web.download_metadata(aip_id, aip_name, warc_collection, job_id, seed_id, current_download, log_path)
 

--- a/scripts/web_aip_batch.py
+++ b/scripts/web_aip_batch.py
@@ -99,13 +99,19 @@ for warc in warc_metadata['files']:
         aip.log(log_path, 'WARC information is formatted wrong.')
         continue
 
+    # Calculates the job id from the WARC filename.
+    try:
+        regex_job_id = re.match(r"^.*-JOB(\d+)", warc_filename)
+        job_id = regex_job_id.group(1)
+    except AttributeError:
+        aip.log(log_path, "Cannot calculate the WARC job id.")
+        continue
+
     # Saves relevant information the WARC's seed in variables for future use.
     # Stops processing if the WARC does not the required metadata.
-    # TODO: dont' get crawl definition here anymore
     try:
         aip_id = seed_metadata[seed_id][0]
         aip_title = seed_metadata[seed_id][1]
-        crawl_definition = seed_metadata[seed_id][2]
     except (KeyError, IndexError):
         aip.log(log_path, 'Seed has no metadata.')
         continue
@@ -123,7 +129,7 @@ for warc in warc_metadata['files']:
     # the folder is empty). A seed may have multiple WARCs and only want to download the seed's reports once.
     # TODO: don't need crawl definition here anymore
     if len(os.listdir(f'{aip_name}/metadata')) == 0:
-        web.download_metadata(aip_id, aip_name, warc_collection, crawl_definition, seed_id, current_download, log_path)
+        web.download_metadata(aip_id, aip_name, warc_collection, job_id, seed_id, current_download, log_path)
 
     # Downloads the WARC from Archive-It into the seed's objects folder.
     web.download_warc(aip_name, warc_filename, warc_url, warc_md5, current_download, log_path)

--- a/scripts/web_aip_single.py
+++ b/scripts/web_aip_single.py
@@ -30,11 +30,11 @@ def seed_data():
     function used by web_aip_batch.py since the AIP id does not need to be calculated."""
 
     # Uses the Partner API to get data about this seed.
-    seed_report = requests.get(f'{c.partner_api}/seed?id={seed_id}', auth=(c.username, c.password))
+    seed_report = requests.get(f"{c.partner_api}/seed?id={seed_id}", auth=(c.username, c.password))
 
     # If there was an error with the API call, quits the script.
     if not seed_report.status_code == 200:
-        aip.log(log_path, f'\nAPI error {seed_report.status_code} for seed report.')
+        aip.log(log_path, f"\nAPI error {seed_report.status_code} for seed report.")
         print("API error, ending script. See log for details.")
         exit()
 
@@ -52,7 +52,7 @@ def seed_data():
             title = seed_info['metadata']['Title'][0]['value']
             crawl_def = seed_info['crawl_definition']
         except (KeyError, IndexError):
-            aip.log(log_path, f'Seed {seed_info["id"]} has no metadata.')
+            aip.log(log_path, f"Seed {seed_info['id']} has no metadata.")
             raise ValueError
 
     return title, crawl_def
@@ -73,7 +73,7 @@ def check_aip():
 
         # If there was an API error, ends the function.
         if warcs.status_code != 200:
-            aip.log(log_path, f'WASAPI error: {warcs.status_code}.')
+            aip.log(log_path, f"WASAPI error: {warcs.status_code}.")
             raise ValueError
 
         # Starts variables used to verify that the script processes the right number of WARCs. The total number of WARCs
@@ -91,7 +91,7 @@ def check_aip():
                 regex_seed = re.match(r".*-SEED(\d+)-.*", warc_info['filename'])
                 warc_seed_identifier = regex_seed.group(1)
             except AttributeError:
-                aip.log(log_path, f'No seed for {warc_info["warc_filename"]}.')
+                aip.log(log_path, f"No seed for {warc_info['warc_filename']}.")
                 raise ValueError
 
             # Filter one: do not count the WARC if it is from a different seed.
@@ -105,7 +105,7 @@ def check_aip():
                 regex_crawl_date = re.match(r"(\d{4}-\d{2}-\d{2})T.*", warc_info['crawl-start'])
                 crawl_date = regex_crawl_date.group(1)
             except AttributeError:
-                aip.log(log_path, f'No date for {warc_info["warc_filename"]}.')
+                aip.log(log_path, f"No date for {warc_info['warc_filename']}.")
                 raise ValueError
 
             if crawl_date < last_download:
@@ -117,59 +117,59 @@ def check_aip():
 
         # Checks that the right number of WARCs were evaluated.
         if warcs_from_api != warcs_include + warcs_exclude:
-            aip.log(log_path, 'Script did not review expected number of WARCs.')
+            aip.log(log_path, "Script did not review expected number of WARCs.")
             raise ValueError
 
         return warcs_include
 
     # Saves the file paths to the metadata and objects folders to variables, since they are long and reused.
-    objects = f'{c.script_output}/aips_{current_download}/{aip_id}_bag/data/objects'
-    metadata = f'{c.script_output}/aips_{current_download}/{aip_id}_bag/data/metadata'
+    objects = f"{c.script_output}/aips_{current_download}/{aip_id}_bag/data/objects"
+    metadata = f"{c.script_output}/aips_{current_download}/{aip_id}_bag/data/metadata"
 
     # List of suffixes used for the expected metadata reports.
-    expected_endings = ('_coll.csv', '_collscope.csv', '_crawldef.csv', '_crawljob.csv', '_seed.csv',
-                        '_seedscope.csv', '_preservation.xml', '_fits.xml')
+    expected_endings = ("_coll.csv", "_collscope.csv", "_crawldef.csv", "_crawljob.csv", "_seed.csv",
+                        "_seedscope.csv", "_preservation.xml", "_fits.xml")
 
     # Calculates the number of WARCs that should be in this AIP. Exits the function if it is not calculated since
     # multiple tests depend on this.
     try:
         warcs_expected = aip_warcs_count()
     except ValueError:
-        print('Cannot check AIP for completeness. WARC count not calculated.')
+        print("Cannot check AIP for completeness. WARC count not calculated.")
         return
 
     # Tests if there is a folder for this AIP in the AIPs directory.
-    if not any(folder.startswith(aip_id) for folder in os.listdir(f'{c.script_output}/aips_{current_download}')):
-        print('The AIP folder was not created.')
+    if not any(folder.startswith(aip_id) for folder in os.listdir(f"{c.script_output}/aips_{current_download}")):
+        print("The AIP folder was not created.")
 
     # Tests if each of the expected metadata reports is present. Skips FITS because the filename is formatted
     # differently and it is checked in the next test.
     # TODO: Is there a way to verify the number of crawl definition reports is correct?
     for end in expected_endings:
-        if end == '_fits.xml':
+        if end == "_fits.xml":
             continue
-        if not os.path.exists(f'{metadata}/{aip_id}{end}'):
-            print(end, 'was not created.')
+        if not os.path.exists(f"{metadata}/{aip_id}{end}"):
+            print(end, "was not created.")
 
     # Tests if the number of FITS files is correct (one for each WARC).
-    fits_count = len([file for file in os.listdir(metadata) if file.endswith('_fits.xml')])
+    fits_count = len([file for file in os.listdir(metadata) if file.endswith("_fits.xml")])
     if not fits_count == warcs_expected:
-        print(f'The number of FITS files is incorrect: {fits_count} instead of {warcs_expected}.')
+        print(f"The number of FITS files is incorrect: {fits_count} instead of {warcs_expected}.")
 
     # Tests if everything in the AIP's metadata folder is an expected file type.
     for file in os.listdir(metadata):
         if not file.endswith(expected_endings):
-            print('File in metadata folder that is not expected:', file)
+            print("File in metadata folder that is not expected:", file)
 
     # Tests if the number of WARCs is correct.
-    warcs_in_objects = len([file for file in os.listdir(objects) if file.endswith('.warc.gz')])
+    warcs_in_objects = len([file for file in os.listdir(objects) if file.endswith(".warc.gz")])
     if not warcs_expected == warcs_in_objects:
-        print(f'The number of WARCs is incorrect: {warcs_in_objects} instead of {warcs_expected}')
+        print(f"The number of WARCs is incorrect: {warcs_in_objects} instead of {warcs_expected}")
 
     # Tests if everything in the AIP's objects folder is a WARC.
     for file in os.listdir(objects):
-        if not file.endswith('.warc.gz'):
-            print('File in objects folder that is not a WARC:', file)
+        if not file.endswith(".warc.gz"):
+            print("File in objects folder that is not a WARC:", file)
 
 
 # Tests required script arguments were provided and assigns to variables.
@@ -178,51 +178,51 @@ try:
     aip_id = sys.argv[2]
     collection_id = sys.argv[3]
 except IndexError:
-    print('Exiting script: missing required argument(s). Must include seed id, AIP id, and collection id.')
+    print("Exiting script: missing required argument(s). Must include seed id, AIP id, and collection id.")
     exit()
 
 # Tests optional script argument was provided and assigns to variable. Must be formatted YYYY-MM-DD.
 # If no last download date is given, sets the date as when UGA Libraries' began web archiving.
 try:
     last_download = sys.argv[4]
-    if not re.match(r'\d{4}-\d{2}-\d{2}', last_download):
-        print('Exiting script: date argument must be formatted YYYY-MM-DD.')
+    if not re.match(r"\d{4}-\d{2}-\d{2}", last_download):
+        print("Exiting script: date argument must be formatted YYYY-MM-DD.")
         exit()
 except IndexError:
-    last_download = '2019-06-01'
+    last_download = "2019-06-01"
 
 # Extracts the department from the aip_id saves it to a variable. Quits the script if the AIP id is formatted wrong.
 try:
-    regex_dept = re.match('^(harg|rbrl).*', aip_id)
+    regex_dept = re.match("^(harg|rbrl).*", aip_id)
     department = regex_dept.group(1)
 except AttributeError:
-    print('Exiting script: AIP id is not formatted correctly. Department could not be identified.')
+    print("Exiting script: AIP id is not formatted correctly. Department could not be identified.")
     exit()
 
-print(f'Making AIP for {seed_id}.')
+print(f"Making AIP for {seed_id}.")
 
 # Makes a folder for aips within the script_output folder, a designated place on the local machine for web archiving
 # documents. The folder name includes today's date to keep it separate from previous downloads which may still be
 # saved on the same machine. current_download is a variable because it is also used as part of the quality_control
 # function, and depending on how long it takes to download WARCs, recalculating today() may give a different result.
 current_download = datetime.date.today()
-aips_directory = f'aips_{current_download}'
-if not os.path.exists(f'{c.script_output}/{aips_directory}'):
-    os.makedirs(f'{c.script_output}/{aips_directory}')
+aips_directory = f"aips_{current_download}"
+if not os.path.exists(f"{c.script_output}/{aips_directory}"):
+    os.makedirs(f"{c.script_output}/{aips_directory}")
 
 # Changes current directory to the aips folder.
-os.chdir(f'{c.script_output}/{aips_directory}')
+os.chdir(f"{c.script_output}/{aips_directory}")
 
 # Starts a log for saving status information about the script. Saving to a document instead of printing to the screen
 # since it allows for a permanent record of the download and because the terminal closed at the end of a script when
 # it is run automatically with chronjob. The log is not started until after the current_download variable is set so that
 # can be included in the file name.
-log_path = f'../script_log_{current_download}.txt'
-aip.log(log_path, f'\nStarting web preservation script on {current_download}.\n')
+log_path = f"../script_log_{current_download}.txt"
+aip.log(log_path, f"\nStarting web preservation script on {current_download}.\n")
 
 
 # PART ONE: DOWNLOAD WARCS AND METADATA INTO THE AIP DIRECTORY STRUCTURE.
-print('Downloading AIP content.')
+print("Downloading AIP content.")
 
 # Uses WASAPI to get information about the WARCs for this seed's collection. The WARC's seed id is checked before it
 # is downloaded to skip other seeds from this collection. It is not possible to filter by seed using WASAPI.
@@ -233,8 +233,8 @@ warc_metadata = web.warc_data(last_download, log_path, collection_id)
 try:
     aip_title, crawl_definition = seed_data()
 except ValueError:
-    aip.log(log_path, 'Seed has no metadata.')
-    print('Exiting script: seed has no metadata.')
+    aip.log(log_path, "Seed has no metadata.")
+    print("Exiting script: seed has no metadata.")
     exit()
 
 # Makes the aip directory for the seed's aip (aip folder with metadata and objects subfolders). Unlike with the batch
@@ -255,16 +255,16 @@ for warc in warc_metadata['files']:
         warc_url = warc['locations'][0]
         warc_md5 = warc['checksums']['md5']
     except (KeyError, IndexError):
-        aip.log(log_path, 'WARC information is formatted wrong.')
+        aip.log(log_path, "WARC information is formatted wrong.")
         continue
 
     # Checks if the WARC is from the seed being downloaded. If not, skips the WARC.
     # The WARC's seed id is the portion of the WARC's filename between "-SEED" and "-".
     try:
-        regex_seed_id = re.match(r'^.*-SEED(\d+)-', warc_filename)
+        regex_seed_id = re.match(r"^.*-SEED(\d+)-", warc_filename)
         warc_seed_id = regex_seed_id.group(1)
     except AttributeError:
-        aip.log(log_path, 'Cannot calculate the WARC seed id.')
+        aip.log(log_path, "Cannot calculate the WARC seed id.")
         continue
     if not seed_id == warc_seed_id:
         continue
@@ -277,35 +277,35 @@ web.find_empty_directory(log_path)
 
 
 # PART TWO: CREATE AIPS THAT ARE READY FOR INGEST INTO ARCHIVE
-print('Converting into an AIP.')
+print("Converting into an AIP.")
 
 # Makes directories used to store script outputs, if they aren't already there.
 aip.make_output_directories()
 
 # Extracts technical metadata from the files using FITS.
 if aip_id in os.listdir('.'):
-    aip.extract_metadata(aip_id, f'{c.script_output}/{aips_directory}', log_path)
+    aip.extract_metadata(aip_id, f"{c.script_output}/{aips_directory}", log_path)
 
 # Transforms the FITS metadata into the PREMIS preservation.xml file using saxon and xslt stylesheets. Determines the
 # third argument (ARCHive group name) from the department code parsed from the folder name.
 if aip_id in os.listdir('.'):
-    aip.make_preservationxml(aip_id, aip_title, department, 'website', log_path)
+    aip.make_preservationxml(aip_id, aip_title, department, "website", log_path)
 
 # Bags the aip.
 if aip_id in os.listdir('.'):
     aip.bag(aip_id, log_path)
 
 # Tars, and zips the aip.
-if f'{aip_id}_bag' in os.listdir('.'):
+if f"{aip_id}_bag" in os.listdir('.'):
     aip.package(aip_id, os.getcwd())
 
 # If the AIP has not been moved to the errors folder, verifies the AIP is complete. Errors are printed to the terminal.
-if f'{aip_id}_bag' in os.listdir('.'):
-    print('\nStarting completeness check.')
+if f"{aip_id}_bag" in os.listdir('.'):
+    print("\nStarting completeness check.")
     check_aip()
 
 # Makes MD5 manifest of the AIP.
 aip.make_manifest()
 
 # Adds completion of the script to the log.
-aip.log(log_path, f'\nScript finished running at {datetime.datetime.today()}.')
+aip.log(log_path, f"\nScript finished running at {datetime.datetime.today()}.")

--- a/scripts/web_aip_single.py
+++ b/scripts/web_aip_single.py
@@ -233,10 +233,6 @@ except ValueError:
 # script, the folder does not need to temporarily include the AIP title since the title is already stored in a variable.
 web.make_aip_directory(aip_id)
 
-# Downloads the seed metadata from Archive-It into the seed's metadata folder.
-# The aip_id is passed twice, as both the AIP id and AIP folder. These are different values for the batch script.
-web.download_metadata(aip_id, aip_id, collection_id, seed_id, current_download, log_path)
-
 # Iterates through information about each WARC.
 for warc in warc_metadata['files']:
 
@@ -259,6 +255,19 @@ for warc in warc_metadata['files']:
         continue
     if not seed_id == warc_seed_id:
         continue
+
+    # Calculates the job id from the WARC filename.
+    try:
+        regex_job_id = re.match(r"^.*-JOB(\d+)", warc_filename)
+        job_id = regex_job_id.group(1)
+    except AttributeError:
+        aip.log(log_path, "Cannot calculate the WARC job id.")
+        continue
+
+    # Downloads the seed metadata from Archive-It into the seed's metadata folder.
+    # The aip_id is passed twice, as both the AIP id and AIP folder. These are different values for the batch script.
+    # While five of the reports are the same for each WARC, the crawl definition could be different.
+    web.download_metadata(aip_id, aip_id, collection_id, job_id, seed_id, current_download, log_path)
 
     # Downloads the warc from Archive-It into the seed's objects folder.
     web.download_warc(aip_id, warc_filename, warc_url, warc_md5, current_download, log_path)

--- a/scripts/web_aip_single.py
+++ b/scripts/web_aip_single.py
@@ -47,6 +47,7 @@ def seed_data():
 
         # Gets the title for the seed from the Title field.
         # Stops processing this seed if the title is missing. It is required.
+        # TODO: don't need crawl definition anymore. This is only the most recent.
         try:
             title = seed_info['metadata']['Title'][0]['value']
             crawl_def = seed_info['crawl_definition']
@@ -143,6 +144,7 @@ def check_aip():
 
     # Tests if each of the expected metadata reports is present. Skips FITS because the filename is formatted
     # differently and it is checked in the next test.
+    # TODO: Is there a way to verify the number of crawl definition reports is correct?
     for end in expected_endings:
         if end == '_fits.xml':
             continue
@@ -227,6 +229,7 @@ print('Downloading AIP content.')
 warc_metadata = web.warc_data(last_download, log_path, collection_id)
 
 # Uses the Archive-It Partner API to get information about this seed.
+# TODO: don't get crawl definition here anymore
 try:
     aip_title, crawl_definition = seed_data()
 except ValueError:
@@ -240,6 +243,7 @@ web.make_aip_directory(aip_id)
 
 # Downloads the seed metadata from Archive-It into the seed's metadata folder.
 # The aip_id is passed twice, as both the AIP id and AIP folder. These are different values for the batch script.
+# TODO: don't need crawl definition here anymore
 web.download_metadata(aip_id, aip_id, collection_id, crawl_definition, seed_id, current_download, log_path)
 
 # Iterates through information about each WARC.

--- a/scripts/web_functions.py
+++ b/scripts/web_functions.py
@@ -236,9 +236,10 @@ def download_metadata(aip_id, aip_folder, warc_collection, job_id, seed_id, curr
         # Saves the metadata report if there were no errors with the API and the report has not already been downloaded.
         # If there is more than one WARC for a seed, reports may already be in the metadata folder.
         report_path = f'{c.script_output}/aips_{current_download}/{aip_folder}/metadata/{report_name}'
-        if metadata_report.status_code == 200 and not os.path.exists(report_path):
-            with open(f'{aip_folder}/metadata/{report_name}', 'wb') as report_csv:
-                report_csv.write(metadata_report.content)
+        if metadata_report.status_code == 200:
+            if not os.path.exists(report_path):
+                with open(f'{aip_folder}/metadata/{report_name}', 'wb') as report_csv:
+                    report_csv.write(metadata_report.content)
         else:
             aip.log(log_path, f'Could not download {report_type} report. Error: {metadata_report.status_code}')
 

--- a/scripts/web_functions.py
+++ b/scripts/web_functions.py
@@ -199,10 +199,9 @@ def seed_data(py_warcs, current_download, log_path):
             # Constructs the AIP id for the seed.
             identifier = f'{department_code}-{related_collection}-web-{download_date_code}-{sequential_number}'
 
-            # Saves AIP id, AIP title, and crawl definition id to the seeds_include dictionary.
-            # TODO: don't need crawl definition anymore
+            # Saves AIP id and AIP title to the seeds_include dictionary.
             # This only contains information about seeds that had no errors and were fully processed.
-            seeds_include[seed_identifier] = [identifier, title, seed_info['crawl_definition']]
+            seeds_include[seed_identifier] = [identifier, title]
 
     return seeds_include
 

--- a/scripts/web_functions.py
+++ b/scripts/web_functions.py
@@ -200,6 +200,7 @@ def seed_data(py_warcs, current_download, log_path):
             identifier = f'{department_code}-{related_collection}-web-{download_date_code}-{sequential_number}'
 
             # Saves AIP id, AIP title, and crawl definition id to the seeds_include dictionary.
+            # TODO: don't need crawl definition anymore
             # This only contains information about seeds that had no errors and were fully processed.
             seeds_include[seed_identifier] = [identifier, title, seed_info['crawl_definition']]
 
@@ -221,6 +222,7 @@ def download_metadata(aip_id, aip_folder, warc_collection, crawl_definition, see
     """Uses the Partner API to download six metadata reports to include in the AIPs for archived websites,
     deletes any empty reports (meaning there was no data of that type for this seed), and redacts login information
     from the seed report. """
+    # TODO: do crawl definition separately
 
     def get_report(filter_type, filter_value, report_type, code):
         """Downloads a single metadata report and saves it as a csv in the AIP's metadata folder.
@@ -498,6 +500,7 @@ def check_aips(current_download, last_download, seed_to_aip, log_path):
         metadata = f'{c.script_output}/aips_{current_download}/{aip_id}_bag/data/metadata'
 
         # Tests if each of the six Archive-It metadata reports is present. os.path.exists() returns True/False.
+        # TODO: possible to check for the correct number of crawl definitions?
         result.append(os.path.exists(f'{metadata}/{aip_id}_coll.csv'))
         result.append(os.path.exists(f'{metadata}/{aip_id}_collscope.csv'))
         result.append(os.path.exists(f'{metadata}/{aip_id}_crawldef.csv'))

--- a/scripts/web_functions.py
+++ b/scripts/web_functions.py
@@ -233,8 +233,10 @@ def download_metadata(aip_id, aip_folder, warc_collection, job_id, seed_id, curr
         filters = {'limit': -1, filter_type: filter_value, 'format': 'csv'}
         metadata_report = requests.get(f'{c.partner_api}/{report_type}', params=filters, auth=(c.username, c.password))
 
-        # Saves the metadata report if there were no errors with the API.
-        if metadata_report.status_code == 200:
+        # Saves the metadata report if there were no errors with the API and the report has not already been downloaded.
+        # If there is more than one WARC for a seed, reports may already be in the metadata folder.
+        report_path = f'{c.script_output}/aips_{current_download}/{aip_folder}/metadata/{report_name}'
+        if metadata_report.status_code == 200 and not os.path.exists(report_path):
             with open(f'{aip_folder}/metadata/{report_name}', 'wb') as report_csv:
                 report_csv.write(metadata_report.content)
         else:
@@ -297,7 +299,6 @@ def download_metadata(aip_id, aip_folder, warc_collection, job_id, seed_id, curr
         for job in crawljob_data:
             if job_id == job['id']:
                 crawl_def_id = job['crawl_definition']
-                # TODO: verify if this report already exists prior to downloading it.
                 get_report('id', crawl_def_id, 'crawl_definition', f'{aip_id}_{crawl_def_id}_crawldef.csv')
                 break
 


### PR DESCRIPTION
Download all crawl definitions associated with the collection instead of just the most recent one by getting the crawl definition id(s) from the crawl job instead of the seed report.